### PR TITLE
Removal of version number from page titles

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,12 +1,14 @@
 <pubmeta>
 <header>main</header>
-<title>XProc 3.0 - Home</title>
+<title>XProc - Home</title>
 <head>homepage</head>
 </pubmeta>
 
-<h1>XProc 3.0</h1>
+<h1>XProc</h1>
 
-XProc is an XML based programming language for processing documents in pipelines: chaining conversions and other steps together to achieve the desired results. The current version is 3.0. 
+XProc is an XML based programming language for processing documents in pipelines: chaining conversions and other steps together to achieve the desired results. This site is dedicated to XProc version 3.0 and higher. 
+
+The current stable version of the Xproc specification is [3.0](https://xproc.org/specifications.html#current). Version 3.1, a relatively minor update, is currently (2024) under development.
 
 XProc has been around, in its 1.0 version, since 2010. All information about this older version can be found [here](https://archive.xproc.org).
 
@@ -21,6 +23,6 @@ The following are important sources of information about XProc 3.0:
 * You can find XProc on GitHub at [https://github.com/xproc](https://github.com/xproc)
 * Join in or visit the archives of the [XProc mailing list](https://lists.w3.org/Archives/Public/xproc-dev/): `xproc-dev@w3.org`
 
-The XProc 3.0 specification is maintained by Achim&#160;Berndzen, Gerrit&#160;Imsieke, Erik&#160;Siegel and Norman&#160;Tovey-Walsh. 
+The XProc specification is maintained by Achim&#160;Berndzen, Gerrit&#160;Imsieke, Erik&#160;Siegel and Norman&#160;Tovey-Walsh. 
  
 

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -1,9 +1,9 @@
 <pubmeta>
 <header>main</header>
-<title>XProc 3.0 - Introduction</title>
+<title>XProc - Introduction</title>
 </pubmeta>
 
-<h1>XProc 3.0 - Introduction</h1>
+<h1>XProc - Introduction</h1>
 
 What is XProc? Let's try to answer this with an overview of its main characteristics:
 
@@ -28,4 +28,4 @@ So why would we do this in the world of information and document processing? One
 
 For straight transformation of XML data there are languages available, like XSLT and XQuery. But more often than not tasks are more complex than can be done in a single transformation: chaining, splitting and merging comes into play. Surrounding the transformations you need housekeeping, like where to read from or write to, inspect directories and zip files and write logs. Also from a software engineering point of view it is often desirable to work in smaller steps to get more legible and better maintainable code. This is where XProc comes into play: a single executable language to express this.
 
-A more thorough introduction can be found in the article *[Introduction to XProc 3.0](https://www.xml.com/articles/2019/11/05/introduction-xproc-30/)* at the [xml.com website](https://www.xml.com/). And: we have collected as many learning materials about XProc 3.0 as we could find [here](learning.html) (conference talks, webinars, articles, etc.). 
+A more thorough introduction can be found in the article *[Introduction to XProc 3.0](https://www.xml.com/articles/2019/11/05/introduction-xproc-30/)* at the [xml.com website](https://www.xml.com/). And: we have collected as many learning materials about XProc as we could find [here](learning.html) (conference talks, webinars, articles, etc.). 

--- a/src/learning.md
+++ b/src/learning.md
@@ -1,9 +1,11 @@
 <pubmeta>
 <header>main</header>
-<title>XProc 3.0 - Learning</title>
+<title>XProc - Learning</title>
 </pubmeta>
 
-<h1>XProc 3.0 - Learning</h1>
+<h1>XProc - Learning</h1>
+
+We have collected as many learning materials as possible about XProc. This is all about version 3.0 (and also usable for 3.1).
 
 <h2>Book</h2>
 
@@ -13,9 +15,9 @@
 
 The *XProc 3.0 Programmer Reference* by Erik Siegel is available for sale [here](https://xmlpress.net/publications/xproc-3-0/).
 
-<h2>XProc 3.0 101</h2>
+<h2>XProc 101</h2>
 
-Introductory learning materials about XProc 3.0:
+Introductory learning materials about XProc:
 
 * Articles:
   * [An Introduction to XProc 3.0](https://www.xml.com/articles/2019/11/05/introduction-xproc-30/) (Erik&#160;Siegel on [xml.com](https://www.xml.com/))
@@ -32,9 +34,9 @@ Introductory learning materials about XProc 3.0:
   * [XProc 3.0 101 - Part 2](https://youtu.be/q0JSy07O2_I) (Erik&#160;Siegel at [Markup UK](https://markupuk.org/) 2020)
   
   
-<h2>XProc 3.0 Advanced</h2>
+<h2>XProc Advanced</h2>
 
-Information about the more advanced usage of XProc 3.0:
+Information about the more advanced usage of XProc:
 
 * Articles:
   * [XProc 3.0 - Strategies for merging documents](https://www.xml.com/articles/2020/11/16/xproc-30-strategies-merging-documents/) (Erik&#160;Siegel on [xml.com](https://www.xml.com/)) 
@@ -46,9 +48,9 @@ Information about the more advanced usage of XProc 3.0:
     * [Text Documents in XProc 3.0](https://youtu.be/xwR8sH8vc8Q) (Achim&#160;Berndzen at [Markup UK](https://markupuk.org/) 2020)
   
   
-<h2>XProc 3.0 History</h2>
+<h2>XProc History</h2>
 
-Materials from XProc 3.0's illustrious history:
+Materials from XProc (3.0) illustrious history:
 
 * Recorded conference talks:
   * [Excellent XProc 3.0](https://youtu.be/O51aE311BKU) (Erik&#160;Siegel at [XML Prague](https://www.xmlprague.cz/) 2019) 

--- a/src/processors.md
+++ b/src/processors.md
@@ -1,11 +1,11 @@
 <pubmeta>
 <header>main</header>
-<title>XProc 3.0 - Processors</title>
+<title>XProc - Processors</title>
 </pubmeta>
 
-<h1>XProc 3.0 - Processors</h1>
+<h1>XProc - Processors</h1>
 
-There are two XProc 3.0 processors, currently (September 2022) under development. Both also have an XProc 1.0 version available.
+There are two XProc processors for version 3.0. Both also have an XProc 1.0 version available.
 
 <h2>MorganaXProc-III</h2>
 

--- a/src/specifications.md
+++ b/src/specifications.md
@@ -1,6 +1,6 @@
 <pubmeta>
 <header>main</header>
-<title>XProc Specifications</title>
+<title>XProc - Specifications</title>
 </pubmeta>
 
 # XProc 3.1 — “Last Call” Specifications

--- a/src/test-suite.md
+++ b/src/test-suite.md
@@ -1,9 +1,9 @@
 <pubmeta>
 <header>main</header>
-<title>XProc 3.0 - Test suite</title>
+<title>XProc - Test suite</title>
 </pubmeta>
 
-<h1>XProc 3.0 - Test suite</h1>
+<h1>XProc - Test suite</h1>
 
 A test suite [test suite](https://test-suite.xproc.org/) is being developed to improve the reliability and interoperability of XProc&#160;3.0 implementations. There are several ways to view the test suite, including:
 


### PR DESCRIPTION
Resolves #46: I removed the **3.0** in the page titles (because we're working on 3.1)  and added a few words here an there to make the distinction between 1.0 and 3.0.
